### PR TITLE
Updated module name variable on server setup

### DIFF
--- a/nwnx-server-setup/mod-start.sh
+++ b/nwnx-server-setup/mod-start.sh
@@ -72,7 +72,7 @@ echo "Starting $MODNAME. Log is $LOGFILE"
 export NWNX_CORE_LOAD_PATH=~/nwnx/Binaries
 LD_PRELOAD=~/nwnx/Binaries/NWNX_Core.so \
  ./nwserver-linux \
-  -module '$MODNAME' \
+  -module $MODNAME \
   -maxclients 96 \
   -minlevel 1 \
   -maxlevel 20 \

--- a/nwnx-server-setup/mod-start.sh
+++ b/nwnx-server-setup/mod-start.sh
@@ -72,7 +72,7 @@ echo "Starting $MODNAME. Log is $LOGFILE"
 export NWNX_CORE_LOAD_PATH=~/nwnx/Binaries
 LD_PRELOAD=~/nwnx/Binaries/NWNX_Core.so \
  ./nwserver-linux \
-  -module $MODNAME \
+  -module "$MODNAME" \
   -maxclients 96 \
   -minlevel 1 \
   -maxlevel 20 \


### PR DESCRIPTION
Removed apostrophes from $MODNAME on server setup command so the variable would be correctly parsed.

**Update:**
Using double quotes instead of single quotes now, in order to support multi-word module names (I.E: "Forgotten Realms.mod")

This is not tested but it **should** work, I'd appreciate if someone could test it since I currently don't have a Linux environment to test. 

I'll try to setup one over the weekend, but if someone could save me the extra work it'd be greatly appreciated!