### PR TITLE
various fixes for nwnltr.c

### DIFF
--- a/nwnltr.c
+++ b/nwnltr.c
@@ -138,7 +138,7 @@ void build_ltr(const char *filename, struct ltrfile *ltr) {
     int midcount = 0;
     while (scanf("%255s", buf) == 1) {
         for (q = buf; *q; q++) {
-            if (((*q) == 0x0d) || ((*q) == 0x0a)) // stop on CR, LF
+            if (((*q) == 0x0d) || ((*q) == 0x0a) || ((*q) == '#')) // stop on CR, LF, or #
                 break;
             *q = tolower(*q);
             if (idx(*q) == -1) {

--- a/nwnltr.c
+++ b/nwnltr.c
@@ -136,23 +136,31 @@ void build_ltr(const char *filename, struct ltrfile *ltr) {
     ltr->header.num_letters = NUM_LETTERS;
 
     char buf[256] = {0};
-    char *p, *q;
     int count = 0;
     int midcount = 0;
     while (scanf("%255s", buf) == 1) {
-        for (q = buf; *q; q++) {
-            if (((*q) == 0x0d) || ((*q) == 0x0a) || ((*q) == '#')) // stop on CR, LF, or #
+        char buf2[256] = {0};
+        char *p = buf2, *q = buf2;
+        for (char *r = buf; *r; r++) {
+            if ((*r) == '#') // stop on # to allow comments
                 break;
-            *q = tolower(*q);
-            if (idx(*q) == -1) {
-                fprintf(stderr, "Invalid character %c (%02x) in name %s. Skipping\n", *q, *q, buf);
+            *r = tolower(*r);
+            if (idx(*r) == -1) {
+                fprintf(stderr, "Invalid character %c (%02x) in name \"%s\". Skipping character.\n", *r, (uint8_t)*r, buf);
                 fflush(stderr);
                 continue;
             }
+            *q++ = *r;
         }
-        if ((q - buf) < 3) continue; // least 3 characters in name
+        *q = '\0';
 
-        p = buf; q--; count++;
+        if ((q - buf2) < 3) { // we need at least 3 characters in a name
+            fprintf(stderr, "Name \"%s\" is too short. Skipping name.\n", buf2);
+            fflush(stderr);
+            continue;
+        }
+
+        q--; count++;
 
         ltr->data.singles.start[idx(p[0])]                       += 1.0;
         ltr->data.doubles[idx(p[0])].start[idx(p[1])]            += 1.0;

--- a/nwnltr.c
+++ b/nwnltr.c
@@ -330,7 +330,7 @@ again:
         }
 
         if (i == ltr->header.num_letters) {
-            if (--p - namebuf < 2 || ++attempts > 100)
+            if (--p - namebuf < 3 || ++attempts > 100)
                 goto again;
         }
     }

--- a/nwnltr.c
+++ b/nwnltr.c
@@ -80,22 +80,25 @@ void parse_cmdline(int argc, char *argv[]) {
 // NOTE: Game does not support more than 28 letters.
 // Files can have fewer (just alpha), but there is no point as the special ones
 // can just be given a probability of 0 to achieve the same effect.
-// Thus, 28 is hardcoded here, for ease of file IO.
-#define MAX_LETTERS 28
+// Thus, the value 28 is hardcoded here, for ease of file IO, but can be
+// overridden at compile time.
+#ifndef NUM_LETTERS
+#define NUM_LETTERS 28
+#endif
 static const char letters[] = "abcdefghijklmnopqrstuvwxyz'-";
 struct ltr_header {
     char     magic[8];
     uint8_t  num_letters;
 };
 struct cdf {
-    float start  [MAX_LETTERS];
-    float middle [MAX_LETTERS];
-    float end    [MAX_LETTERS];
+    float start  [NUM_LETTERS];
+    float middle [NUM_LETTERS];
+    float end    [NUM_LETTERS];
 };
 struct ltrdata {
     struct cdf singles;
-    struct cdf doubles[MAX_LETTERS];
-    struct cdf triples[MAX_LETTERS][MAX_LETTERS];
+    struct cdf doubles[NUM_LETTERS];
+    struct cdf triples[NUM_LETTERS][NUM_LETTERS];
 };
 struct ltrfile {
     struct ltr_header header;
@@ -118,8 +121,8 @@ void load_ltr(const char *filename, struct ltrfile *ltr) {
     if (fread(&ltr->header, 9, 1, f) != 1 || strncmp(ltr->header.magic, "LTR V1.0", 8))
         die("File %s has no valid LTR header", filename);
 
-    if (ltr->header.num_letters != MAX_LETTERS)
-        die("File built for %d letters, tool only supports %d.", ltr->header.num_letters, MAX_LETTERS);
+    if (ltr->header.num_letters != NUM_LETTERS)
+        die("File built for %d letters, tool only supports %d.", ltr->header.num_letters, NUM_LETTERS);
 
     if (fread(&ltr->data, sizeof(ltr->data), 1, f) != 1)
         die("Unable to read the prob table from %s. Truncated file?", filename);
@@ -130,7 +133,7 @@ void load_ltr(const char *filename, struct ltrfile *ltr) {
 void build_ltr(const char *filename, struct ltrfile *ltr) {
     memset(ltr, 0, sizeof(*ltr));
     strncpy(ltr->header.magic, "LTR V1.0", 8);
-    ltr->header.num_letters = MAX_LETTERS;
+    ltr->header.num_letters = NUM_LETTERS;
 
     char buf[256] = {0};
     char *p, *q;

--- a/nwnltr.c
+++ b/nwnltr.c
@@ -102,8 +102,8 @@ struct ltrfile {
 
 static float nrand() { return (float)rand() / RAND_MAX; }
 static int idx(char letter) {
-    if (letter == '\'') return 27;
-    if (letter == '-')  return 28;
+    if (letter == '\'') return 26;
+    if (letter == '-')  return 27;
     if (letter >= 'a' && letter <= 'z') return letter - 'a';
     return -1;
 }
@@ -134,15 +134,17 @@ void build_ltr(const char *filename, struct ltrfile *ltr) {
     char *p, *q;
     int count = 0;
     int midcount = 0;
-    while (scanf("%s", buf) == 1) {
+    while (scanf("%255s", buf) == 1) {
         for (q = buf; *q; q++) {
+            if (((*q) == 0x0d) || ((*q) == 0x0a)) // stop on CR, LF
+                break;
             *q = tolower(*q);
             if (idx(*q) == -1) {
                 fprintf(stderr, "Invalid character %c in name %s. Skipping\n", *q, buf);
                 continue;
             }
         }
-        if ((q - buf) < 2) continue; // least 3 characters in name
+        if ((q - buf) < 3) continue; // least 3 characters in name
 
         p = buf; q--; count++;
 

--- a/nwnltr.c
+++ b/nwnltr.c
@@ -46,6 +46,7 @@ struct cfg {
 #define die(format, ...)                                \
     do {                                                \
         fprintf(stderr, format "\n", ##__VA_ARGS__);    \
+        fflush(stderr);                                 \
         exit(~0);                                       \
     } while(0)
 
@@ -141,6 +142,7 @@ void build_ltr(const char *filename, struct ltrfile *ltr) {
             *q = tolower(*q);
             if (idx(*q) == -1) {
                 fprintf(stderr, "Invalid character %c in name %s. Skipping\n", *q, buf);
+                fflush(stderr);
                 continue;
             }
         }


### PR DESCRIPTION
Fixes the idx off-by-one error for ' and -
Fixes LF characters on stdin on windows causing idx to return -1 and index off the bottom of the letter probability arrays
Fixes input names shorter than 3 characters causing an out of bounds array access and crash
Adds a more verbose display of invalid input characters in case they are not printed in a distinguishable way
Flush stderr after writing to it, since otherwise in some circumstances it doesn't get flushed to console at a consistent point in execution
Add a compile time definition of the number of letters in the file, so both 26 and 28 letter variants can be handled